### PR TITLE
添加商品重量的展示

### DIFF
--- a/pages/goods-details/index.wxml
+++ b/pages/goods-details/index.wxml
@@ -14,7 +14,12 @@
 	<view class="goods-info">
 		<view class="goods-left">
 			<view class="goods-title">{{goodsDetail.basicInfo.name}}</view>
-			<view class="goods-characteristic">{{goodsDetail.basicInfo.characteristic}}</view>
+			<view class="goods-characteristic">
+				<text> {{goodsDetail.basicInfo.characteristic}} </text>
+				<block wx:if="{{goodsDetail.basicInfo.weight != 0}}">
+				    <text> \t {{goodsDetail.basicInfo.weight}}千克 </text>
+				</block>
+			</view>
 		</view>
 		<block wx:if="{{goodsDetail.basicInfo.pingtuan == false}}">
 			<view class="goods-price">¥ {{selectSizePrice}}</view>


### PR DESCRIPTION
如果商品的重量不是0,在商品的名称下面一行显示商品的重量。商品重量这个项对于生鲜或者外卖品类还是有一些用处。
代码经过测试