### PR TITLE
过滤还没到生效时间的优惠券

### DIFF
--- a/pages/to-pay-order/index.js
+++ b/pages/to-pay-order/index.js
@@ -2,6 +2,7 @@ const app = getApp()
 const WXAPI = require('apifm-wxapi')
 const AUTH = require('../../utils/auth')
 const wxpay = require('../../utils/pay.js')
+const tools = require('../../utils/tools.js')
 
 Page({
 	data: {
@@ -301,9 +302,17 @@ Page({
 			status: 0
 		}).then(function(res) {
 			if (res.code == 0) {
+				// 过滤不满足满减最低金额的优惠券
 				var coupons = res.data.filter(entity => {
 					return entity.moneyHreshold <= that.data.allGoodsAndYunPrice;
 				});
+				
+				var dayTime = tools.formatTime(new Date());
+				//过滤还没到可以使用时间的优惠券
+				coupons = coupons.filter(entity =>{
+				    return entity.dateStart <= dayTime;
+				});
+				
 				if (coupons.length > 0) {
 					that.setData({
 						hasNoCoupons: false,

--- a/utils/tools.js
+++ b/utils/tools.js
@@ -35,7 +35,27 @@ function isStrInArray(item, arr) {
 	}
 	return false;
 }
+// 返回api工厂一样格式的当前时间
+function formatTime(date) {
+  var year = date.getFullYear()
+  var month = date.getMonth() + 1
+  var day = date.getDate()
+
+  var hour = date.getHours()
+  var minute = date.getMinutes()
+  var second = date.getSeconds()
+
+  return [year, month, day].map(formatNumber).join('-') + ' ' + [hour, minute, second].map(formatNumber).join(':')
+}
+
+function formatNumber(n) {
+  n = n.toString()
+  return n[1] ? n : '0' + n
+}
+
+
 module.exports = {
 	showTabBarBadge: showTabBarBadge,
 	isStrInArray: isStrInArray,
+	formatTime: formatTime,
 }


### PR DESCRIPTION
目前应该是没有过滤没到生效时间的优惠券，后台是有这个选项的，甲方希望做定时的活动，要加这个功能。
在util/tools里加了一个函数格式化当前时间，之后在过滤优惠券的地方加了一个过滤没到生效日期的filter