### PR TITLE
添加了后台设置最低提现金额的功能

### DIFF
--- a/pages/withdraw/index.wxml
+++ b/pages/withdraw/index.wxml
@@ -15,7 +15,7 @@
 					<text class="lable-amount">¥</text>
 					<input name="amount" class="input" type="number" />
 				</view>
-				<view class="lable-text">提现金额100元起，1～5个工作日到账</view>
+				<view class="lable-text">提现金额{{minWithdrawAmount}}元起，1～5个工作日到账</view>
 			</view>
 		</view>
 		<button class="save-btn" formType="submit">确认提现</button>


### PR DESCRIPTION
1. 甲方希望能在后台设置最低提现金额，在后台添加了一个参数设置这个金额。如果用户的后台没有参数或者因为任何类似网慢的原因请求失败，都会默认用100元最低提现金额。
2. 对不满足最低提现金额和输入为空区分报错，用户看着应该更清楚一点。
3. 清理了一下没用到的生命周期。
4. 代码经过正常使用和断网条件测试